### PR TITLE
Fix for transaction crushing due to invalid user input format 

### DIFF
--- a/src/main/java/longah/exception/ExceptionMessage.java
+++ b/src/main/java/longah/exception/ExceptionMessage.java
@@ -13,7 +13,7 @@ public enum ExceptionMessage {
 
     // Transaction Exceptions
     INVALID_TRANSACTION_FORMAT ("Invalid transaction format.", ExceptionType.WARNING),
-    INVALID_TIME_FORMAT ("Invalid time format.", ExceptionType.WARNING),
+    INVALID_TIME_FORMAT ("Invalid DateTime format.", ExceptionType.WARNING),
     INVALID_TRANSACTION_VALUE ("Invalid transaction value.", ExceptionType.WARNING),
     INVALID_VALUE_FORMAT ("Invalid value format.", ExceptionType.WARNING),
     NO_TRANSACTION_FOUND ("Transaction list is empty.", ExceptionType.INFO),

--- a/src/main/java/longah/node/Transaction.java
+++ b/src/main/java/longah/node/Transaction.java
@@ -104,6 +104,9 @@ public class Transaction {
 
         if (splitInput[0].contains("t/")) { //presence of time component in expression
             String[] splitLenderTime = splitInput[0].split("t/");
+            if (splitLenderTime[0].contains("t/")) {
+                throw new LongAhException(ExceptionMessage.INVALID_TRANSACTION_FORMAT);
+            }
             lenderName = splitLenderTime[0].trim();
             try {
                 this.transactionTime = LocalDateTime.parse(splitLenderTime[1].trim(),

--- a/src/main/java/longah/node/Transaction.java
+++ b/src/main/java/longah/node/Transaction.java
@@ -95,14 +95,14 @@ public class Transaction {
         // User input format: [Lender] t/[transactionTime(opt)] p/[Borrower1] a/[amount1] p/[Borrower2] a/[amount2] ...
 
         String[] splitInput = expression.split("p/");
-        if (splitInput.length < 2 || splitInput[0].isEmpty()) {
+        if (splitInput.length < 2 || splitInput[0].isEmpty() || splitInput[1].contains(("t/"))) {
             // Minimum of 2 people as part of a transaction
             throw new LongAhException(ExceptionMessage.INVALID_TRANSACTION_FORMAT);
         }
         assert splitInput.length >= 2 : "Invalid transaction.";
         String lenderName;
 
-        if (expression.contains("t/")) { //presence of time component in expression
+        if (splitInput[0].contains("t/")) { //presence of time component in expression
             String[] splitLenderTime = splitInput[0].split("t/");
             lenderName = splitLenderTime[0].trim();
             try {


### PR DESCRIPTION
Fixed issue with program crushing when user inputs time component in the wrong format when adding transactions.